### PR TITLE
remove unset($this) for PHP 7.1

### DIFF
--- a/aicclib.php
+++ b/aicclib.php
@@ -48,7 +48,6 @@ class StringTokenizer {
 	 */
 	public function __destruct()
 	{
-		unset($this);
 	}
 
 	/**


### PR DESCRIPTION
causing "cannot unset $this" error in PHP 7+